### PR TITLE
Fix README merge markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,7 @@ This project is **frontend only**. The Affiliate CMS stores data in the browser'
 localStorage, so no server or backend setup is required.
 
 The `docs/affiliates_cms.patch` file contains the full diff introducing the Affiliate CMS and aesthetic improvements, while `docs/wireframe.md` provides a high-level diagram of the current layout.
-<<<<<<< ours
-<<<<<<< ours
-=======
 See `docs/patch_summary.md` for a table describing each stored patch.
->>>>>>> theirs
 
 ## Managing Blog Posts
 
@@ -97,16 +93,12 @@ Blog articles live in `src/pages/Blog.js` as an array of post objects. Each post
 includes an `id`, `title`, `summary`, and `fullContent` field. Simply edit this
 file and add a new object to the array to publish a new article. Reload the
 development server to see your changes.
-=======
-See `docs/patch_summary.md` for a table describing each stored patch.
 
-## Managing Blog Posts
 
 Open the **Blog Admin** page (`/blog-cms`) to add new posts directly in the browser.
 Fill out the form with a title, summary, and full content. Posts are stored in
 `localStorage` and appear on the Blog page automatically. You can still edit
 `src/pages/Blog.js` to change the default posts shipped with the project.
->>>>>>> theirs
 
 ## Managing Affiliate Products
 
@@ -115,7 +107,20 @@ Affiliate CMS. Fill out the form to add a product name, image URL, description,
 and purchase link. Items are saved in your browser's `localStorage` and will
 appear on the Affiliates page. You can remove an entry by clicking its **Delete**
 button or by clearing browser storage.
-<<<<<<< ours
-=======
 The admin page is password protected with the password `7vY3p$92q`.
->>>>>>> theirs
+
+## Available Patch Files
+
+The `docs` folder contains patch files that apply various updates to this project.
+See [`docs/patch_summary.md`](docs/patch_summary.md) for details on each patch.
+
+- `blog_cms.patch` – adds the blog management CMS.
+- `affiliates_cms.patch` – introduces the affiliate product manager.
+- `bmi_tool.patch` – installs the BMI calculator tool.
+- `aesthetic_update.patch` – applies general styling improvements.
+- `theme_update.patch` – updates fonts and colors for the site theme.
+- `admin_dropdown.patch` – provides a dropdown for admin controls.
+- `full_update.patch` – applies all of the above changes at once.
+
+Apply `full_update.patch` if you want every feature in one go, or choose
+individual patches to update selectively.


### PR DESCRIPTION
## Summary
- clean up leftover merge markers in README
- keep short "Available Patch Files" section

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684700a6ba00832ca219db1835aa86bf